### PR TITLE
Remove composer version field

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
   "name": "spotonlive/php-google-my-business",
   "type": "library",
-  "version": "4.4.0",
   "description": "Google MyBusiness",
   "keywords": [
     "google my business", "mybusiness", "gmb"


### PR DESCRIPTION
If the version is present in the composer.json composer will consider that tag invalid as it has conflicting version information.

It is recommend  that the version is left out from the composer.json since the version is taken from the tags and branches which package users are referencing.

Error example:
Writing /Users/marko.antolovic/.composer/cache/repo/github.com/spotonlive/php-google-my-business/62fa5901e73e90d11ba540ace7ce1d3922ac93fa into cache
Skipped tag 4.5, tag (4.5.0.0) does not match version (4.4.0.0) in composer.json

Here is the Jordi Boggiano answer on this topic.
https://stackoverflow.com/questions/36769404/what-is-the-meaning-of-version-field-in-composer-json